### PR TITLE
chore(deps): update plexus-utils

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,14 @@
             <artifactId>mojo-executor</artifactId>
             <version>2.4.0</version>
         </dependency>
+        <!-- Upgrade of plexus-utils for mojo-executor -->
+        <!-- Important: to keep Maven3 compat, remain in [3,4) range! -->
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-utils</artifactId>
+            <version>3.5.1</version>
+        </dependency>
+
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>


### PR DESCRIPTION
Update plexus-utils that is transitive dependency on mojo-executor to latest and leave note to stay away from p-u 4.x line.