### PR TITLE
feat: make use of ToolRunner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,27 +14,28 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        java: [ 8, 11 ]
+        java: [ 8, 21 ]
         os: [ ubuntu-latest, windows-latest ]
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Cache local Maven repository
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
       - name: Set up JDK ${{ matrix.java }}
-        uses: joschi/setup-jdk@v2
+        uses: actions/setup-java@v5
         with:
+          distribution: 'temurin'
           java-version: ${{ matrix.java }}
 
       - name: Build with Maven
-        run: ./mvnw --no-transfer-progress verify
+        run: ./mvnw -e --no-transfer-progress --update-snapshots verify
 
 
   deploy:
@@ -42,11 +43,12 @@ jobs:
     runs-on: ubuntu-latest 
     steps:
     
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Java/Maven
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v5
         with:
-          java-version: 1.8
+          distribution: 'temurin'
+          java-version: 8
           server-id: ossrh
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,18 +1,3 @@
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.6/apache-maven-3.9.6-bin.zip
-wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.2.0/maven-wrapper-3.2.0.jar
+wrapperVersion=3.3.4
+distributionType=only-script
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.15/apache-maven-3.9.15-bin.zip

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,3 +1,3 @@
 wrapperVersion=3.3.4
 distributionType=only-script
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.15/apache-maven-3.9.15-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.16/apache-maven-3.9.16-bin.zip

--- a/mvnw
+++ b/mvnw
@@ -19,7 +19,7 @@
 # ----------------------------------------------------------------------------
 
 # ----------------------------------------------------------------------------
-# Apache Maven Wrapper startup batch script, version 3.2.0
+# Apache Maven Wrapper startup batch script, version 3.3.4
 #
 # Optional ENV vars
 # -----------------
@@ -35,15 +35,17 @@ set -euf
 # OS specific support.
 native_path() { printf %s\\n "$1"; }
 case "$(uname)" in
-(CYGWIN*|MINGW*) [ -z "${JAVA_HOME-}" ] || JAVA_HOME="$(cygpath --unix "$JAVA_HOME")"
-                 native_path() { cygpath --path --windows "$1"; } ;;
+CYGWIN* | MINGW*)
+  [ -z "${JAVA_HOME-}" ] || JAVA_HOME="$(cygpath --unix "$JAVA_HOME")"
+  native_path() { cygpath --path --windows "$1"; }
+  ;;
 esac
 
 # set JAVACMD and JAVACCMD
 set_java_home() {
   # For Cygwin and MinGW, ensure paths are in Unix format before anything is touched
-  if [ -n "${JAVA_HOME-}" ] ; then
-    if [ -x "$JAVA_HOME/jre/sh/java" ] ; then
+  if [ -n "${JAVA_HOME-}" ]; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ]; then
       # IBM's JDK on AIX uses strange locations for the executables
       JAVACMD="$JAVA_HOME/jre/sh/java"
       JAVACCMD="$JAVA_HOME/jre/sh/javac"
@@ -51,17 +53,25 @@ set_java_home() {
       JAVACMD="$JAVA_HOME/bin/java"
       JAVACCMD="$JAVA_HOME/bin/javac"
 
-      if [ ! -x "$JAVACMD" ] || [ ! -x "$JAVACCMD" ] ; then
+      if [ ! -x "$JAVACMD" ] || [ ! -x "$JAVACCMD" ]; then
         echo "The JAVA_HOME environment variable is not defined correctly, so mvnw cannot run." >&2
         echo "JAVA_HOME is set to \"$JAVA_HOME\", but \"\$JAVA_HOME/bin/java\" or \"\$JAVA_HOME/bin/javac\" does not exist." >&2
         return 1
       fi
     fi
   else
-    JAVACMD="$('set' +e; 'unset' -f command 2>/dev/null; 'command' -v java)" || :
-    JAVACCMD="$('set' +e; 'unset' -f command 2>/dev/null; 'command' -v javac)" || :
+    JAVACMD="$(
+      'set' +e
+      'unset' -f command 2>/dev/null
+      'command' -v java
+    )" || :
+    JAVACCMD="$(
+      'set' +e
+      'unset' -f command 2>/dev/null
+      'command' -v javac
+    )" || :
 
-    if [ ! -x "${JAVACMD-}" ] || [ ! -x "${JAVACCMD-}" ] ; then
+    if [ ! -x "${JAVACMD-}" ] || [ ! -x "${JAVACCMD-}" ]; then
       echo "The java/javac command does not exist in PATH nor is JAVA_HOME set, so mvnw cannot run." >&2
       return 1
     fi
@@ -72,7 +82,8 @@ set_java_home() {
 hash_string() {
   str="${1:-}" h=0
   while [ -n "$str" ]; do
-    h=$(( ( h * 31 + $(LC_CTYPE=C printf %d "'$str") ) % 4294967296 ))
+    char="${str%"${str#?}"}"
+    h=$(((h * 31 + $(LC_CTYPE=C printf %d "'$char")) % 4294967296))
     str="${str#?}"
   done
   printf %x\\n $h
@@ -86,32 +97,43 @@ die() {
   exit 1
 }
 
+trim() {
+  # MWRAPPER-139:
+  #   Trims trailing and leading whitespace, carriage returns, tabs, and linefeeds.
+  #   Needed for removing poorly interpreted newline sequences when running in more
+  #   exotic environments such as mingw bash on Windows.
+  printf "%s" "${1}" | tr -d '[:space:]'
+}
+
+scriptDir="$(dirname "$0")"
+scriptName="$(basename "$0")"
+
 # parse distributionUrl and optional distributionSha256Sum, requires .mvn/wrapper/maven-wrapper.properties
 while IFS="=" read -r key value; do
   case "${key-}" in
-    distributionUrl) distributionUrl="${value-}" ;;
-    distributionSha256Sum) distributionSha256Sum="${value-}" ;;
+  distributionUrl) distributionUrl=$(trim "${value-}") ;;
+  distributionSha256Sum) distributionSha256Sum=$(trim "${value-}") ;;
   esac
-done < "${0%/*}/.mvn/wrapper/maven-wrapper.properties"
-[ -n "${distributionUrl-}" ] || die "cannot read distributionUrl property in ${0%/*}/.mvn/wrapper/maven-wrapper.properties"
-
+done <"$scriptDir/.mvn/wrapper/maven-wrapper.properties"
+[ -n "${distributionUrl-}" ] || die "cannot read distributionUrl property in $scriptDir/.mvn/wrapper/maven-wrapper.properties"
 
 case "${distributionUrl##*/}" in
-(maven-mvnd-*bin.*)
+maven-mvnd-*bin.*)
   MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/
   case "${PROCESSOR_ARCHITECTURE-}${PROCESSOR_ARCHITEW6432-}:$(uname -a)" in
-  (*AMD64:CYGWIN*|*AMD64:MINGW*) distributionPlatform=windows-amd64 ;;
-  (:Darwin*x86_64) distributionPlatform=darwin-amd64 ;;
-  (:Darwin*arm64) distributionPlatform=darwin-aarch64 ;;
-  (:Linux*x86_64*) distributionPlatform=linux-amd64 ;;
-  (*) echo "Cannot detect native platform for mvnd on $(uname)-$(uname -m), use pure java version" >&2
-      distributionPlatform=linux-amd64
-      ;;
+  *AMD64:CYGWIN* | *AMD64:MINGW*) distributionPlatform=windows-amd64 ;;
+  :Darwin*x86_64) distributionPlatform=darwin-amd64 ;;
+  :Darwin*arm64) distributionPlatform=darwin-aarch64 ;;
+  :Linux*x86_64*) distributionPlatform=linux-amd64 ;;
+  *)
+    echo "Cannot detect native platform for mvnd on $(uname)-$(uname -m), use pure java version" >&2
+    distributionPlatform=linux-amd64
+    ;;
   esac
   distributionUrl="${distributionUrl%-bin.*}-$distributionPlatform.zip"
   ;;
-(maven-mvnd-*) MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/ ;;
-(*) MVN_CMD="mvn${0##*/mvnw}" _MVNW_REPO_PATTERN=/org/apache/maven/ ;;
+maven-mvnd-*) MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/ ;;
+*) MVN_CMD="mvn${scriptName#mvnw}" _MVNW_REPO_PATTERN=/org/apache/maven/ ;;
 esac
 
 # apply MVNW_REPOURL and calculate MAVEN_HOME
@@ -120,7 +142,8 @@ esac
 distributionUrlName="${distributionUrl##*/}"
 distributionUrlNameMain="${distributionUrlName%.*}"
 distributionUrlNameMain="${distributionUrlNameMain%-bin}"
-MAVEN_HOME="$HOME/.m2/wrapper/dists/${distributionUrlNameMain-}/$(hash_string "$distributionUrl")"
+MAVEN_USER_HOME="${MAVEN_USER_HOME:-${HOME}/.m2}"
+MAVEN_HOME="${MAVEN_USER_HOME}/wrapper/dists/${distributionUrlNameMain-}/$(hash_string "$distributionUrl")"
 
 exec_maven() {
   unset MVNW_VERBOSE MVNW_USERNAME MVNW_PASSWORD MVNW_REPOURL || :
@@ -133,8 +156,8 @@ if [ -d "$MAVEN_HOME" ]; then
 fi
 
 case "${distributionUrl-}" in
-(*?-bin.zip|*?maven-mvnd-?*-?*.zip) ;;
-(*) die "distributionUrl is not valid, must match *-bin.zip or maven-mvnd-*.zip, but found '${distributionUrl-}'" ;;
+*?-bin.zip | *?maven-mvnd-?*-?*.zip) ;;
+*) die "distributionUrl is not valid, must match *-bin.zip or maven-mvnd-*.zip, but found '${distributionUrl-}'" ;;
 esac
 
 # prepare tmp dir
@@ -168,17 +191,17 @@ case "${MVNW_PASSWORD:+has-password}" in
 has-password) [ -n "${MVNW_USERNAME-}" ] || MVNW_USERNAME='' MVNW_PASSWORD='' ;;
 esac
 
-if [ -z "${MVNW_USERNAME-}" ] && command -v wget > /dev/null; then
+if [ -z "${MVNW_USERNAME-}" ] && command -v wget >/dev/null; then
   verbose "Found wget ... using wget"
-  wget ${__MVNW_QUIET_WGET:+"$__MVNW_QUIET_WGET"} "$distributionUrl" -O "$TMP_DOWNLOAD_DIR/$distributionUrlName"
-elif [ -z "${MVNW_USERNAME-}" ] && command -v curl > /dev/null; then
+  wget ${__MVNW_QUIET_WGET:+"$__MVNW_QUIET_WGET"} "$distributionUrl" -O "$TMP_DOWNLOAD_DIR/$distributionUrlName" || die "wget: Failed to fetch $distributionUrl"
+elif [ -z "${MVNW_USERNAME-}" ] && command -v curl >/dev/null; then
   verbose "Found curl ... using curl"
-  curl ${__MVNW_QUIET_CURL:+"$__MVNW_QUIET_CURL"} -f -L -o "$TMP_DOWNLOAD_DIR/$distributionUrlName" "$distributionUrl"
+  curl ${__MVNW_QUIET_CURL:+"$__MVNW_QUIET_CURL"} -f -L -o "$TMP_DOWNLOAD_DIR/$distributionUrlName" "$distributionUrl" || die "curl: Failed to fetch $distributionUrl"
 elif set_java_home; then
   verbose "Falling back to use Java to download"
   javaSource="$TMP_DOWNLOAD_DIR/Downloader.java"
   targetZip="$TMP_DOWNLOAD_DIR/$distributionUrlName"
-  cat > "$javaSource" <<-END
+  cat >"$javaSource" <<-END
 	public class Downloader extends java.net.Authenticator
 	{
 	  protected java.net.PasswordAuthentication getPasswordAuthentication()
@@ -188,13 +211,13 @@ elif set_java_home; then
 	  public static void main( String[] args ) throws Exception
 	  {
 	    setDefault( new Downloader() );
-	    java.nio.file.Files.copy( new java.net.URL( args[0] ).openStream(), java.nio.file.Paths.get( args[1] ).toAbsolutePath().normalize() );
+	    java.nio.file.Files.copy( java.net.URI.create( args[0] ).toURL().openStream(), java.nio.file.Paths.get( args[1] ).toAbsolutePath().normalize() );
 	  }
 	}
 	END
   # For Cygwin/MinGW, switch paths to Windows format before running javac and java
   verbose " - Compiling Downloader.java ..."
-  "$(native_path "$JAVACCMD")" "$(native_path "$javaSource")"
+  "$(native_path "$JAVACCMD")" "$(native_path "$javaSource")" || die "Failed to compile Downloader.java"
   verbose " - Running Downloader.java ..."
   "$(native_path "$JAVACMD")" -cp "$(native_path "$TMP_DOWNLOAD_DIR")" Downloader "$distributionUrl" "$(native_path "$targetZip")"
 fi
@@ -206,12 +229,12 @@ if [ -n "${distributionSha256Sum-}" ]; then
     echo "Checksum validation is not supported for maven-mvnd." >&2
     echo "Please disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
     exit 1
-  elif command -v sha256sum > /dev/null; then
-    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | sha256sum -c > /dev/null 2>&1; then
+  elif command -v sha256sum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | sha256sum -c - >/dev/null 2>&1; then
       distributionSha256Result=true
     fi
-  elif command -v shasum > /dev/null; then
-    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | shasum -a 256 -c > /dev/null 2>&1; then
+  elif command -v shasum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | shasum -a 256 -c >/dev/null 2>&1; then
       distributionSha256Result=true
     fi
   else
@@ -227,13 +250,46 @@ if [ -n "${distributionSha256Sum-}" ]; then
 fi
 
 # unzip and move
-if command -v unzip > /dev/null; then
-  unzip ${__MVNW_QUIET_UNZIP:+"$__MVNW_QUIET_UNZIP"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -d "$TMP_DOWNLOAD_DIR"
+if command -v unzip >/dev/null; then
+  unzip ${__MVNW_QUIET_UNZIP:+"$__MVNW_QUIET_UNZIP"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -d "$TMP_DOWNLOAD_DIR" || die "failed to unzip"
 else
-  tar xzf${__MVNW_QUIET_TAR:+"$__MVNW_QUIET_TAR"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -C "$TMP_DOWNLOAD_DIR"
+  tar xzf${__MVNW_QUIET_TAR:+"$__MVNW_QUIET_TAR"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -C "$TMP_DOWNLOAD_DIR" || die "failed to untar"
 fi
-printf %s\\n "$distributionUrl" > "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain/mvnw.url"
-mv -- "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain" "$MAVEN_HOME" || [ -d "$MAVEN_HOME" ] || die "fail to move MAVEN_HOME"
+
+# Find the actual extracted directory name (handles snapshots where filename != directory name)
+actualDistributionDir=""
+
+# First try the expected directory name (for regular distributions)
+if [ -d "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain" ]; then
+  if [ -f "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain/bin/$MVN_CMD" ]; then
+    actualDistributionDir="$distributionUrlNameMain"
+  fi
+fi
+
+# If not found, search for any directory with the Maven executable (for snapshots)
+if [ -z "$actualDistributionDir" ]; then
+  # enable globbing to iterate over items
+  set +f
+  for dir in "$TMP_DOWNLOAD_DIR"/*; do
+    if [ -d "$dir" ]; then
+      if [ -f "$dir/bin/$MVN_CMD" ]; then
+        actualDistributionDir="$(basename "$dir")"
+        break
+      fi
+    fi
+  done
+  set -f
+fi
+
+if [ -z "$actualDistributionDir" ]; then
+  verbose "Contents of $TMP_DOWNLOAD_DIR:"
+  verbose "$(ls -la "$TMP_DOWNLOAD_DIR")"
+  die "Could not find Maven distribution directory in extracted archive"
+fi
+
+verbose "Found extracted Maven distribution directory: $actualDistributionDir"
+printf %s\\n "$distributionUrl" >"$TMP_DOWNLOAD_DIR/$actualDistributionDir/mvnw.url"
+mv -- "$TMP_DOWNLOAD_DIR/$actualDistributionDir" "$MAVEN_HOME" || [ -d "$MAVEN_HOME" ] || die "fail to move MAVEN_HOME"
 
 clean || :
 exec_maven "$@"

--- a/mvnw.cmd
+++ b/mvnw.cmd
@@ -19,7 +19,7 @@
 @REM ----------------------------------------------------------------------------
 
 @REM ----------------------------------------------------------------------------
-@REM Apache Maven Wrapper startup batch script, version 3.2.0
+@REM Apache Maven Wrapper startup batch script, version 3.3.4
 @REM
 @REM Optional ENV vars
 @REM   MVNW_REPOURL - repo url base for downloading maven distribution
@@ -40,7 +40,7 @@
 @SET __MVNW_ARG0_NAME__=
 @SET MVNW_USERNAME=
 @SET MVNW_PASSWORD=
-@IF NOT "%__MVNW_CMD__%"=="" (%__MVNW_CMD__% %*)
+@IF NOT "%__MVNW_CMD__%"=="" ("%__MVNW_CMD__%" %*)
 @echo Cannot start maven from wrapper >&2 && exit /b 1
 @GOTO :EOF
 : end batch / begin powershell #>
@@ -73,13 +73,30 @@ switch -wildcard -casesensitive ( $($distributionUrl -replace '^.*/','') ) {
 # apply MVNW_REPOURL and calculate MAVEN_HOME
 # maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,maven-mvnd-<version>-<platform>}/<hash>
 if ($env:MVNW_REPOURL) {
-  $MVNW_REPO_PATTERN = if ($USE_MVND) { "/org/apache/maven/" } else { "/maven/mvnd/" }
-  $distributionUrl = "$env:MVNW_REPOURL$MVNW_REPO_PATTERN$($distributionUrl -replace '^.*'+$MVNW_REPO_PATTERN,'')"
+  $MVNW_REPO_PATTERN = if ($USE_MVND -eq $False) { "/org/apache/maven/" } else { "/maven/mvnd/" }
+  $distributionUrl = "$env:MVNW_REPOURL$MVNW_REPO_PATTERN$($distributionUrl -replace "^.*$MVNW_REPO_PATTERN",'')"
 }
 $distributionUrlName = $distributionUrl -replace '^.*/',''
 $distributionUrlNameMain = $distributionUrlName -replace '\.[^.]*$','' -replace '-bin$',''
-$MAVEN_HOME_PARENT = "$HOME/.m2/wrapper/dists/$distributionUrlNameMain"
-$MAVEN_HOME_NAME = ([System.Security.Cryptography.MD5]::Create().ComputeHash([byte[]][char[]]$distributionUrl) | ForEach-Object {$_.ToString("x2")}) -join ''
+
+$MAVEN_M2_PATH = "$HOME/.m2"
+if ($env:MAVEN_USER_HOME) {
+  $MAVEN_M2_PATH = "$env:MAVEN_USER_HOME"
+}
+
+if (-not (Test-Path -Path $MAVEN_M2_PATH)) {
+    New-Item -Path $MAVEN_M2_PATH -ItemType Directory | Out-Null
+}
+
+$MAVEN_WRAPPER_DISTS = $null
+if ((Get-Item $MAVEN_M2_PATH).Target[0] -eq $null) {
+  $MAVEN_WRAPPER_DISTS = "$MAVEN_M2_PATH/wrapper/dists"
+} else {
+  $MAVEN_WRAPPER_DISTS = (Get-Item $MAVEN_M2_PATH).Target[0] + "/wrapper/dists"
+}
+
+$MAVEN_HOME_PARENT = "$MAVEN_WRAPPER_DISTS/$distributionUrlNameMain"
+$MAVEN_HOME_NAME = ([System.Security.Cryptography.SHA256]::Create().ComputeHash([byte[]][char[]]$distributionUrl) | ForEach-Object {$_.ToString("x2")}) -join ''
 $MAVEN_HOME = "$MAVEN_HOME_PARENT/$MAVEN_HOME_NAME"
 
 if (Test-Path -Path "$MAVEN_HOME" -PathType Container) {
@@ -123,6 +140,7 @@ if ($distributionSha256Sum) {
   if ($USE_MVND) {
     Write-Error "Checksum validation is not supported for maven-mvnd. `nPlease disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties."
   }
+  Import-Module $PSHOME\Modules\Microsoft.PowerShell.Utility -Function Get-FileHash
   if ((Get-FileHash "$TMP_DOWNLOAD_DIR/$distributionUrlName" -Algorithm SHA256).Hash.ToLower() -ne $distributionSha256Sum) {
     Write-Error "Error: Failed to validate Maven distribution SHA-256, your Maven distribution might be compromised. If you updated your Maven version, you need to update the specified distributionSha256Sum property."
   }
@@ -130,7 +148,33 @@ if ($distributionSha256Sum) {
 
 # unzip and move
 Expand-Archive "$TMP_DOWNLOAD_DIR/$distributionUrlName" -DestinationPath "$TMP_DOWNLOAD_DIR" | Out-Null
-Rename-Item -Path "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain" -NewName $MAVEN_HOME_NAME | Out-Null
+
+# Find the actual extracted directory name (handles snapshots where filename != directory name)
+$actualDistributionDir = ""
+
+# First try the expected directory name (for regular distributions)
+$expectedPath = Join-Path "$TMP_DOWNLOAD_DIR" "$distributionUrlNameMain"
+$expectedMvnPath = Join-Path "$expectedPath" "bin/$MVN_CMD"
+if ((Test-Path -Path $expectedPath -PathType Container) -and (Test-Path -Path $expectedMvnPath -PathType Leaf)) {
+  $actualDistributionDir = $distributionUrlNameMain
+}
+
+# If not found, search for any directory with the Maven executable (for snapshots)
+if (!$actualDistributionDir) {
+  Get-ChildItem -Path "$TMP_DOWNLOAD_DIR" -Directory | ForEach-Object {
+    $testPath = Join-Path $_.FullName "bin/$MVN_CMD"
+    if (Test-Path -Path $testPath -PathType Leaf) {
+      $actualDistributionDir = $_.Name
+    }
+  }
+}
+
+if (!$actualDistributionDir) {
+  Write-Error "Could not find Maven distribution directory in extracted archive"
+}
+
+Write-Verbose "Found extracted Maven distribution directory: $actualDistributionDir"
+Rename-Item -Path "$TMP_DOWNLOAD_DIR/$actualDistributionDir" -NewName $MAVEN_HOME_NAME | Out-Null
 try {
   Move-Item -Path "$TMP_DOWNLOAD_DIR/$MAVEN_HOME_NAME" -Destination $MAVEN_HOME_PARENT | Out-Null
 } catch {

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss</groupId>
         <artifactId>jboss-parent</artifactId>
-        <version>39</version>
+        <version>53</version>
     </parent>
     <groupId>dev.jbang</groupId>
     <artifactId>jbang-maven-plugin</artifactId>
@@ -39,50 +39,70 @@
     </developers>
 
     <properties>
+        <!-- jboss-parent -->
+        <maven.min.version>3.9.11</maven.min.version>
+        <jdk.min.version>8</jdk.min.version>
+
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- picked up by: compiler, javadoc -->
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
         <mavenMinRuntime.version>3.6.0</mavenMinRuntime.version>
-        <maven.version>3.9.6</maven.version>
-        <mavenPluginTools.version>3.10.2</mavenPluginTools.version>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>eu.maveniverse.maven.toolrunner</groupId>
+                <artifactId>toolrunner</artifactId>
+                <version>0.2.1</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>
-            <groupId>org.zeroturnaround</groupId>
-            <artifactId>zt-exec</artifactId>
-            <version>1.12</version>
+            <groupId>eu.maveniverse.maven.toolrunner</groupId>
+            <artifactId>shared</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.twdata.maven</groupId>
-            <artifactId>mojo-executor</artifactId>
-            <version>2.4.0</version>
-        </dependency>
-        <!-- Upgrade of plexus-utils for mojo-executor -->
-        <!-- Important: to keep Maven3 compat, remain in [3,4) range! -->
-        <dependency>
-            <groupId>org.codehaus.plexus</groupId>
-            <artifactId>plexus-utils</artifactId>
-            <version>3.5.1</version>
+            <groupId>eu.maveniverse.maven.toolrunner.tools</groupId>
+            <artifactId>jbang</artifactId>
         </dependency>
 
+        <!-- MIMA needs logging + hc4 needs it as well (runtime) -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <!-- MIMA runtime: this is a Maven Plugin so embedded-maven -->
+        <dependency>
+            <groupId>eu.maveniverse.maven.mima.runtime</groupId>
+            <artifactId>embedded-maven</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <!-- Maven stuff -->
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
-            <version>${maven.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-core</artifactId>
-            <version>${maven.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
             <artifactId>maven-plugin-annotations</artifactId>
-            <version>${mavenPluginTools.version}</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>
@@ -92,9 +112,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-plugin-plugin</artifactId>
-                <version>${mavenPluginTools.version}</version>
+                <version>3.15.2</version>
                 <configuration>
                     <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
+                    <goalPrefix>jbang</goalPrefix>
+                    <requiredJavaVersion>8</requiredJavaVersion>
+                    <requiredMavenVersion>3.9</requiredMavenVersion>
                 </configuration>
                 <executions>
                     <execution>
@@ -114,7 +137,7 @@
               <plugin>
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.7</version>
+                <version>1.7.0</version>
                 <extensions>true</extensions>
                 <configuration>
                    <serverId>ossrh</serverId>
@@ -154,7 +177,7 @@
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>mrm-maven-plugin</artifactId>
-                        <version>1.5.0</version>
+                        <version>1.7.1</version>
                         <executions>
                             <execution>
                                 <goals>
@@ -170,7 +193,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-invoker-plugin</artifactId>
-                        <version>3.6.0</version>
+                        <version>3.10.1</version>
                         <configuration>
                             <debug>false</debug>
                             <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
@@ -184,6 +207,9 @@
                             <filterProperties>
                                 <repository.proxy.url>${repository.proxy.url}</repository.proxy.url>
                             </filterProperties>
+                            <environmentVariables>
+                                <MAVEN_ARGS>-e --no-transfer-progress</MAVEN_ARGS>
+                            </environmentVariables>
                         </configuration>
                         <dependencies>
                             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
             <dependency>
                 <groupId>eu.maveniverse.maven.toolrunner</groupId>
                 <artifactId>toolrunner</artifactId>
-                <version>0.2.3</version>
+                <version>0.3.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
             <dependency>
                 <groupId>eu.maveniverse.maven.toolrunner</groupId>
                 <artifactId>toolrunner</artifactId>
-                <version>0.2.2</version>
+                <version>0.2.3</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- picked up by: compiler, javadoc -->
         <maven.compiler.release>8</maven.compiler.release>
-        <mavenMinRuntime.version>3.6.0</mavenMinRuntime.version>
+        <mavenMinRuntime.version>3.6.3</mavenMinRuntime.version>
     </properties>
 
     <dependencyManagement>
@@ -54,7 +54,7 @@
             <dependency>
                 <groupId>eu.maveniverse.maven.toolrunner</groupId>
                 <artifactId>toolrunner</artifactId>
-                <version>0.2.1</version>
+                <version>0.2.2</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -116,8 +116,8 @@
                 <configuration>
                     <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
                     <goalPrefix>jbang</goalPrefix>
-                    <requiredJavaVersion>8</requiredJavaVersion>
-                    <requiredMavenVersion>3.9</requiredMavenVersion>
+                    <requiredJavaVersion>${maven.compiler.release}</requiredJavaVersion>
+                    <requiredMavenVersion>${mavenMinRuntime.version}</requiredMavenVersion>
                 </configuration>
                 <executions>
                     <execution>

--- a/src/it/script-with-args/verify.groovy
+++ b/src/it/script-with-args/verify.groovy
@@ -1,6 +1,2 @@
-import java.nio.file.Files
-import java.nio.file.Path
-import java.nio.file.Paths
-
-Path path = Paths.get(basedir.toString(), "build.log" );
-assert new String(Files.readAllBytes(path)).contains("--option1=foo")
+File log = new File(basedir, "build.log" );
+assert log.text.contains("--option1=foo")

--- a/src/it/script-with-jbang-args/verify.groovy
+++ b/src/it/script-with-jbang-args/verify.groovy
@@ -1,8 +1,3 @@
-import java.nio.file.Files
-import java.nio.file.Path
-import java.nio.file.Paths
-
-Path path = Paths.get(basedir.toString(), "build.log" );
-def logs = new String(Files.readAllBytes(path))
-assert logs.contains("--option1=foo")
-assert logs.contains("foo => bar")
+File log = new File(basedir, "build.log" );
+assert log.text.contains("--option1=foo")
+assert log.text.contains("foo => bar")

--- a/src/it/script-with-trust/verify.groovy
+++ b/src/it/script-with-trust/verify.groovy
@@ -1,7 +1,4 @@
 import java.nio.charset.Charset
-import java.nio.file.Files
-import java.nio.file.Path
-import java.nio.file.Paths
 
-Path path = Paths.get(basedir.toString(), "build.log" );
-assert new String(Files.readAllBytes(path)).contains(Locale.getDefault().getLanguage() + "." + Charset.defaultCharset().displayName())
+File log = new File(basedir, "build.log" );
+assert log.text.contains(Locale.getDefault().getLanguage() + "." + Charset.defaultCharset().displayName())

--- a/src/it/script/verify.groovy
+++ b/src/it/script/verify.groovy
@@ -1,6 +1,2 @@
-import java.nio.file.Files
-import java.nio.file.Path
-import java.nio.file.Paths
-
-Path path = Paths.get(basedir.toString(), "build.log" );
-assert new String(Files.readAllBytes(path)).contains("HELLO WORLD")
+File log = new File(basedir, "build.log" );
+assert log.text.contains("HELLO WORLD")

--- a/src/it/skip/verify.groovy
+++ b/src/it/skip/verify.groovy
@@ -1,6 +1,2 @@
-import java.nio.file.Files
-import java.nio.file.Path
-import java.nio.file.Paths
-
-Path path = Paths.get(basedir.toString(), "build.log" );
-assert new String(Files.readAllBytes(path)).contains("Skipping plugin execution")
+File log = new File(basedir, "build.log" );
+assert log.text.contains("Skipping plugin execution")

--- a/src/main/java/dev/jbang/RunMojo.java
+++ b/src/main/java/dev/jbang/RunMojo.java
@@ -4,6 +4,7 @@ package dev.jbang;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -20,12 +21,15 @@ import eu.maveniverse.maven.toolrunner.shared.ToolHandler;
 import eu.maveniverse.maven.toolrunner.shared.ToolManager;
 import eu.maveniverse.maven.toolrunner.tools.jbang.JBangProvider;
 import org.apache.maven.artifact.Artifact;
+import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
+
+import javax.inject.Inject;
 
 /**
  * Run JBang with the specified parameters
@@ -81,8 +85,8 @@ public class RunMojo extends AbstractMojo {
     /**
      * Used for basedir -> CWD
      */
-    @Parameter(defaultValue = "${project}", readonly = true, required = true)
-    protected MavenProject project;
+    @Inject
+    protected MavenSession mavenSession;
 
     @Override
     public void execute() throws MojoExecutionException {
@@ -90,12 +94,19 @@ public class RunMojo extends AbstractMojo {
             getLog().info("Skipping plugin execution");
             return;
         }
+        Path tempDir = null; // use default
+        Path cwd = Paths.get(mavenSession.getExecutionRootDirectory());
+        if (mavenSession.getCurrentProject().getBasedir() != null) {
+            Path output = Paths.get(mavenSession.getCurrentProject().getBuild().getOutputDirectory());
+            tempDir = output.resolve("toolrunner-tmp");
+            cwd = mavenSession.getCurrentProject().getBasedir().toPath();
+        }
         try (ToolManager toolManager = ToolManager.create(
                 Config.builder()
                         .isTransient(false)
                         .allowPathDetection(true)
-                        .tempDirectory(Paths.get(project.getBuild().getOutputDirectory()).resolve("toolrunner-tmp"))
-                        .installationDirectory(jbangInstallDir.toPath())
+                        .tempDirectory(tempDir)
+                        .installationDirectory(jbangInstallDir != null ? jbangInstallDir.toPath() : null)
                         .build())) {
             ToolHandler toolHandler = toolManager.selectToolByName("jbang")
                     .orElseThrow(() -> new IllegalStateException("ToolHandler not found")); // never happens
@@ -123,7 +134,7 @@ public class RunMojo extends AbstractMojo {
                 arguments.addAll(Arrays.asList(args));
             }
             ToolExecution.Builder execution = jbang.executionTemplate()
-                    .cwd(project.getBasedir().toPath())
+                    .cwd(cwd)
                     .arguments(arguments);
             ToolHandle.Result result = jbang.execute(execution.build());
             // we know JBangProvider uses ProcessBuilderExecutor so we insist on exitCode

--- a/src/main/java/dev/jbang/RunMojo.java
+++ b/src/main/java/dev/jbang/RunMojo.java
@@ -4,23 +4,22 @@ package dev.jbang;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Optional;
+import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import eu.maveniverse.maven.toolrunner.shared.Config;
+import eu.maveniverse.maven.toolrunner.shared.ToolExecution;
 import eu.maveniverse.maven.toolrunner.shared.ToolHandle;
 import eu.maveniverse.maven.toolrunner.shared.ToolHandler;
 import eu.maveniverse.maven.toolrunner.shared.ToolManager;
 import eu.maveniverse.maven.toolrunner.tools.jbang.JBangProvider;
 import org.apache.maven.artifact.Artifact;
-import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
@@ -123,19 +122,18 @@ public class RunMojo extends AbstractMojo {
             if (args != null) {
                 arguments.addAll(Arrays.asList(args));
             }
-            ByteArrayOutputStream out = new ByteArrayOutputStream();
-            ByteArrayOutputStream err = new ByteArrayOutputStream();
-            ToolHandle.Result result = jbang.execute(jbang.executionTemplate()
+            ToolExecution.Builder execution = jbang.executionTemplate()
                     .cwd(project.getBasedir().toPath())
-                    .arguments(arguments)
-                    .stdOut(out)
-                    .stdErr(err)
-                    .build());
-            if (!result.success()) {
-                throw new MojoExecutionException("Error while executing JBang.\nstdout: " + out + "\nstderr:" + err);
+                    .arguments(arguments);
+            ToolHandle.Result result = jbang.execute(execution.build());
+            // we know JBangProvider uses ProcessBuilderExecutor so we insist on exitCode
+            int exitCode = result.exitCode().orElseThrow(() -> new NoSuchElementException("Missing exitCode"));
+            if (exitCode != 0) {
+                throw new MojoExecutionException("Error while executing JBang.\nstdout: "
+                        + result.stdOutString().orElse("") + "\nstderr:" + result.stdErrString().orElse(""));
             } else {
                 getLog().info("JBang executed successfully");
-                getLog().info(out.toString());
+                getLog().info(result.stdOutString().orElse(""));
             }
         } catch (IOException e) {
             throw new MojoExecutionException(e.getMessage(), e);
@@ -154,15 +152,14 @@ public class RunMojo extends AbstractMojo {
             // No trust required
             return;
         }
-        ByteArrayOutputStream out = new ByteArrayOutputStream();
-        ByteArrayOutputStream err = new ByteArrayOutputStream();
         ToolHandle.Result result = jbang.execute(jbang.executionTemplate()
                         .arguments(Stream.concat(Stream.of("trust", "add"), Arrays.stream(trusts)).collect(Collectors.toList()))
-                        .stdOut(out)
-                        .stdErr(err)
                         .build());
-        if (!result.success()) {
-            throw new MojoExecutionException("Error while trusting JBang URLs.\nstdout: " + out + "\nstderr:" + err);
+        // we know JBangProvider uses ProcessBuilderExecutor so we insist on exitCode
+        int exitCode = result.exitCode().orElseThrow(() -> new NoSuchElementException("Missing exitCode"));
+        if (exitCode != 0 && exitCode != 1) {
+            throw new MojoExecutionException("Error while trusting JBang URLs.\nstdout: "
+                    + result.stdOutString().orElse("") + "\nstderr:" + result.stdErrString().orElse(""));
         }
     }
 }

--- a/src/main/java/dev/jbang/RunMojo.java
+++ b/src/main/java/dev/jbang/RunMojo.java
@@ -1,32 +1,32 @@
 package dev.jbang;
 
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.IOException;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
+import eu.maveniverse.maven.toolrunner.shared.Config;
+import eu.maveniverse.maven.toolrunner.shared.ToolHandle;
+import eu.maveniverse.maven.toolrunner.shared.ToolHandler;
+import eu.maveniverse.maven.toolrunner.shared.ToolManager;
+import eu.maveniverse.maven.toolrunner.tools.jbang.JBangProvider;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.AbstractMojo;
-import org.apache.maven.plugin.BuildPluginManager;
 import org.apache.maven.plugin.MojoExecutionException;
-import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
-import org.zeroturnaround.exec.ProcessExecutor;
-import org.zeroturnaround.exec.ProcessResult;
-import org.zeroturnaround.exec.stream.slf4j.Slf4jStream;
-
-import static org.twdata.maven.mojoexecutor.MojoExecutor.configuration;
-import static org.twdata.maven.mojoexecutor.MojoExecutor.element;
-import static org.twdata.maven.mojoexecutor.MojoExecutor.executeMojo;
-import static org.twdata.maven.mojoexecutor.MojoExecutor.executionEnvironment;
-import static org.twdata.maven.mojoexecutor.MojoExecutor.goal;
-import static org.twdata.maven.mojoexecutor.MojoExecutor.plugin;
 
 /**
  * Run JBang with the specified parameters
@@ -35,11 +35,6 @@ import static org.twdata.maven.mojoexecutor.MojoExecutor.plugin;
  */
 @Mojo(name = "run", defaultPhase = LifecyclePhase.GENERATE_RESOURCES, requiresProject = false)
 public class RunMojo extends AbstractMojo {
-
-    private static final boolean IS_OS_WINDOWS = System.getProperty("os.name").toLowerCase(Locale.ENGLISH).contains("windows");
-
-    private static final int OK_EXIT_CODE = 0;
-
     /**
      * The arguments to be used for JBang itself
      */
@@ -84,17 +79,11 @@ public class RunMojo extends AbstractMojo {
     @Parameter(property = "jbang.skip")
     private boolean skip;
 
-    // Used in MojoExecutor. See RunMojo#download
+    /**
+     * Used for basedir -> CWD
+     */
     @Parameter(defaultValue = "${project}", readonly = true, required = true)
     protected MavenProject project;
-
-    @Parameter(defaultValue = "${session}")
-    private MavenSession session;
-
-    @Component
-    private BuildPluginManager pluginManager;
-
-    private Path jbangHome;
 
     @Override
     public void execute() throws MojoExecutionException {
@@ -102,77 +91,56 @@ public class RunMojo extends AbstractMojo {
             getLog().info("Skipping plugin execution");
             return;
         }
-        detectJBang();
-        executeTrust();
-        executeJBang();
-    }
-
-    private void detectJBang() throws MojoExecutionException {
-        ProcessResult result = version();
-        if (result.getExitValue() == OK_EXIT_CODE) {
-            getLog().info("Found JBang v." + result.outputString().trim());
-        } else {
-            getLog().warn("JBang not found. Downloading " + (isLatestVersion() ? "the latest version" :
-                    "version " + jbangVersion));
-            download();
-            result = version();
-            if (result.getExitValue() == OK_EXIT_CODE) {
-                getLog().info("Using JBang v." + result.outputString().trim());
+        try (ToolManager toolManager = ToolManager.create(
+                Config.builder()
+                        .isTransient(false)
+                        .allowPathDetection(true)
+                        .tempDirectory(Paths.get(project.getBuild().getOutputDirectory()).resolve("toolrunner-tmp"))
+                        .installationDirectory(jbangInstallDir.toPath())
+                        .build())) {
+            ToolHandler toolHandler = toolManager.selectToolByName("jbang")
+                    .orElseThrow(() -> new IllegalStateException("ToolHandler not found")); // never happens
+            ToolHandle jbang;
+            if (jbangVersion != null && !Artifact.LATEST_VERSION.equals(jbangVersion)) {
+                // parameterize version; user wants exactly specified version
+                HashMap<String, String> jbangMd = new HashMap<>();
+                jbangMd.put(ToolHandler.TOOL_NAME, JBangProvider.NAME);
+                jbangMd.put(ToolHandler.TOOL_VERSION, jbangVersion);
+                jbang = toolHandler.selectTool(jbangMd).orElseThrow(() -> new IllegalStateException("JBang not found"));
+            } else {
+                // use whatever (ie $PATH) or provision LATEST
+                jbang = toolHandler.toolHandle();
             }
+            executeTrust(jbang);
+
+            // execute it
+            List<String> arguments = new ArrayList<>();
+            arguments.add("run");
+            if (jbangargs != null) {
+                arguments.addAll(Arrays.asList(jbangargs));
+            }
+            arguments.add(script);
+            if (args != null) {
+                arguments.addAll(Arrays.asList(args));
+            }
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            ByteArrayOutputStream err = new ByteArrayOutputStream();
+            ToolHandle.Result result = jbang.execute(jbang.executionTemplate()
+                    .cwd(project.getBasedir().toPath())
+                    .arguments(arguments)
+                    .stdOut(out)
+                    .stdErr(err)
+                    .build());
+            if (!result.success()) {
+                throw new MojoExecutionException("Error while executing JBang.\nstdout: " + out + "\nstderr:" + err);
+            } else {
+                getLog().info("JBang executed successfully");
+                getLog().info(out.toString());
+            }
+        } catch (IOException e) {
+            throw new MojoExecutionException(e.getMessage(), e);
         }
     }
-
-    private void download() throws MojoExecutionException {
-        String uri;
-        String homePath;
-        if (isLatestVersion()) {
-            uri = "https://www.jbang.dev/releases/latest/download/jbang.zip";
-            homePath = "jbang";
-        } else {
-            uri = String.format("https://github.com/jbangdev/jbang/releases/download/v%s/jbang-%s.zip",
-                                jbangVersion, jbangVersion);
-            homePath = "jbang-" + jbangVersion;
-        }
-        Path installDir = jbangInstallDir.toPath().resolve(".jbang").toAbsolutePath();
-        getLog().debug("Downloading JBang from " + uri + " and installing in " + installDir);
-        executeMojo(
-                plugin("com.googlecode.maven-download-plugin",
-                       "download-maven-plugin",
-                       "1.6.2"),
-                goal("wget"),
-                configuration(
-                        element("uri", uri),
-                        element("followRedirects", "true"),
-                        element("unpack", "true"),
-                        element("outputDirectory", installDir.toString())
-                ),
-                executionEnvironment(
-                        project,
-                        session,
-                        pluginManager));
-        jbangHome = installDir.resolve(homePath);
-    }
-
-    private boolean isLatestVersion() {
-        return Artifact.LATEST_VERSION.equals(jbangVersion);
-    }
-
-    private ProcessResult version() throws MojoExecutionException {
-        List<String> command = command();
-        command.add(findJBangExecutable() + " version");
-        ProcessResult result = null;
-        try {
-            result = new ProcessExecutor()
-                    .command(command)
-                    .readOutput(true)
-                    .destroyOnExit()
-                    .execute();
-        } catch (Exception e) {
-            throw new MojoExecutionException("Error while fetching the JBang version", e);
-        }
-        return result;
-    }
-
 
     /**
      * Execute "jbang trust add URL..."
@@ -181,83 +149,20 @@ public class RunMojo extends AbstractMojo {
      *                                0: success
      *                                1: Already trusted source(s)
      */
-    private void executeTrust() throws MojoExecutionException {
+    private void executeTrust(ToolHandle jbang) throws MojoExecutionException {
         if (trusts == null || trusts.length == 0) {
             // No trust required
             return;
         }
-        List<String> command = command();
-        command.add(findJBangExecutable() + " trust add " + String.join(" ", trusts));
-        ProcessResult result = execute(command);
-        int exitValue = result.getExitValue();
-        if (exitValue != 0 && exitValue != 1) {
-            throw new MojoExecutionException("Error while trusting JBang URLs. Exit code: " + result.getExitValue());
-        }
-    }
-
-    /**
-     * Execute jbang run script arguments
-     *
-     * @throws MojoExecutionException if exit value != 0
-     */
-    private void executeJBang() throws MojoExecutionException {
-        List<String> command = command();
-        StringBuilder executable = new StringBuilder(findJBangExecutable());
-        executable.append(" run ");
-        if (jbangargs != null) {
-            executable.append(" ").append(String.join(" ", jbangargs)).append(" ");
-        }
-        executable.append(script);
-        if (args != null) {
-            executable.append(" ").append(String.join(" ", args));
-        }
-        command.add(executable.toString());
-        ProcessResult result = execute(command);
-        if (result.getExitValue() != 0) {
-            throw new MojoExecutionException("Error while executing JBang. Exit code: " + result.getExitValue());
-        }
-    }
-
-    private ProcessResult execute(List<String> command) throws MojoExecutionException {
-        try {
-            return new ProcessExecutor()
-                    .command(command)
-                    .redirectOutput(Slf4jStream.ofCaller().asInfo())
-                    .destroyOnExit()
-                    .execute();
-        } catch (Exception e) {
-            throw new MojoExecutionException("Error while executing JBang", e);
-        }
-    }
-
-    /**
-     * @return the command containing the supported shell per OS
-     */
-    private List<String> command() {
-        List<String> command = new ArrayList<>();
-        if (IS_OS_WINDOWS) {
-            command.add("cmd.exe");
-            command.add("/c");
-        } else {
-            command.add("sh");
-            command.add("-c");
-        }
-        return command;
-    }
-
-    private String findJBangExecutable() {
-        if (jbangHome != null) {
-            if (IS_OS_WINDOWS) {
-                return jbangHome.resolve("bin/jbang.cmd").toString();
-            } else {
-                return jbangHome.resolve("bin/jbang").toString();
-            }
-        } else {
-            if (IS_OS_WINDOWS) {
-                return "jbang.cmd";
-            } else {
-                return "jbang";
-            }
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ByteArrayOutputStream err = new ByteArrayOutputStream();
+        ToolHandle.Result result = jbang.execute(jbang.executionTemplate()
+                        .arguments(Stream.concat(Stream.of("trust", "add"), Arrays.stream(trusts)).collect(Collectors.toList()))
+                        .stdOut(out)
+                        .stdErr(err)
+                        .build());
+        if (!result.success()) {
+            throw new MojoExecutionException("Error while trusting JBang URLs.\nstdout: " + out + "\nstderr:" + err);
         }
     }
 }

--- a/src/main/java/dev/jbang/RunMojo.java
+++ b/src/main/java/dev/jbang/RunMojo.java
@@ -133,7 +133,7 @@ public class RunMojo extends AbstractMojo {
             if (args != null) {
                 arguments.addAll(Arrays.asList(args));
             }
-            ToolExecution.Builder execution = jbang.executionTemplate()
+            ToolExecution.Builder execution = ToolExecution.ofCommand("jbang")
                     .cwd(cwd)
                     .arguments(arguments);
             ToolHandle.Result result = jbang.execute(execution.build());
@@ -163,7 +163,7 @@ public class RunMojo extends AbstractMojo {
             // No trust required
             return;
         }
-        ToolHandle.Result result = jbang.execute(jbang.executionTemplate()
+        ToolHandle.Result result = jbang.execute(ToolExecution.ofCommand("jbang")
                         .arguments(Stream.concat(Stream.of("trust", "add"), Arrays.stream(trusts)).collect(Collectors.toList()))
                         .build());
         // we know JBangProvider uses ProcessBuilderExecutor so we insist on exitCode

--- a/src/main/java/dev/jbang/RunMojo.java
+++ b/src/main/java/dev/jbang/RunMojo.java
@@ -1,7 +1,6 @@
 package dev.jbang;
 
 
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
@@ -27,7 +26,6 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
-import org.apache.maven.project.MavenProject;
 
 import javax.inject.Inject;
 
@@ -59,7 +57,7 @@ public class RunMojo extends AbstractMojo {
     /**
      * If the script is in a remote location, what URLs should be trusted
      *
-     * See https://github.com/jbangdev/jbang#urls-from-trusted-sources for more information
+     * See <a href="https://github.com/jbangdev/jbang#urls-from-trusted-sources">JBang URLs from trusted sources</a> for more information
      */
     @Parameter(property = "jbang.trusts")
     private String[] trusts;


### PR DESCRIPTION
Make the plugin `jbang-maven-plugin` use new https://github.com/maveniverse/toolrunner to detect, provision (if not detected, or user did set specific version that was not detected) and execute JBang.

Changes:
* project kept Java 8
* use ToolRunner-jbang provider
* POM parent updated
* update mvnw
* update GH Actions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Maven Wrapper to version 3.3.4 with improved download and verification mechanisms.
  * Upgraded Maven distribution to version 3.9.16 for enhanced stability and security.
  * Bumped JBoss parent POM to version 53 and updated core build plugins for better compatibility and performance.
  * Improved test verification infrastructure with simplified log-reading logic.
  * Enhanced build reliability with better error handling and checksum validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jbangdev/jbang-maven-plugin/pull/13?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->