### PR TITLE
fix: use Njord instead of dead plugin and service

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,7 @@
     <name>JBang Maven Plugin</name>
 
     <url>https://jbang.dev</url>
+    <inceptionYear>2020</inceptionYear>
 
     <prerequisites>
         <maven>${mavenMinRuntime.version}</maven>
@@ -38,6 +39,30 @@
         </developer>
     </developers>
 
+    <scm>
+        <connection>scm:git:https://github.com/jbangdev/jbang-maven-plugin</connection>
+        <developerConnection>scm:git:https://github.com/jbangdev/jbang-maven-plugin</developerConnection>
+        <url>https://github.com/jbangdev/jbang-maven-plugin</url>
+        <tag>HEAD</tag>
+    </scm>
+
+    <distributionManagement>
+        <repository>
+            <id>sonatype-central-portal</id>
+            <name>Sonatype Central Portal</name>
+            <url>https://repo.maven.apache.org/maven2/</url>
+        </repository>
+        <snapshotRepository>
+            <id>sonatype-central-portal</id>
+            <name>Sonatype Central Portal</name>
+            <url>https://central.sonatype.com/repository/maven-snapshots/</url>
+        </snapshotRepository>
+        <site>
+            <id>github</id>
+            <url>${project.scm.connection}</url>
+        </site>
+    </distributionManagement>
+
     <properties>
         <!-- jboss-parent -->
         <maven.min.version>3.9.11</maven.min.version>
@@ -47,6 +72,11 @@
         <!-- picked up by: compiler, javadoc -->
         <maven.compiler.release>8</maven.compiler.release>
         <mavenMinRuntime.version>3.6.3</mavenMinRuntime.version>
+        <!-- publishing: Njord version + config (for now) -->
+        <njordVersion>0.9.6</njordVersion>
+        <njord.autoPublish>true</njord.autoPublish>
+        <njord.publishingType>automatic</njord.publishingType>
+        <njord.waitForStates>true</njord.waitForStates>
     </properties>
 
     <dependencyManagement>
@@ -108,6 +138,15 @@
     </dependencies>
 
     <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>eu.maveniverse.maven.plugins</groupId>
+                    <artifactId>njord</artifactId>
+                    <version>${njordVersion}</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -134,35 +173,16 @@
                     </execution>
                 </executions>
             </plugin>
-              <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.7.0</version>
-                <extensions>true</extensions>
-                <configuration>
-                   <serverId>ossrh</serverId>
-                   <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                   <autoReleaseAfterClose>true</autoReleaseAfterClose>
-                </configuration>
-              </plugin>
         </plugins>
+        <extensions>
+            <extension>
+                <groupId>eu.maveniverse.maven.njord</groupId>
+                <artifactId>extension3</artifactId>
+                <version>${njordVersion}</version>
+            </extension>
+        </extensions>
     </build>
-    <scm>
-        <connection>scm:git:https://github.com/jbangdev/jbang-maven-plugin</connection>
-        <developerConnection>scm:git:https://github.com/jbangdev/jbang-maven-plugin</developerConnection>
-        <url>https://github.com/jbangdev/jbang-maven-plugin</url>
-        <tag>HEAD</tag>
-    </scm>
-    <distributionManagement>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-        <repository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-        </repository>
-    </distributionManagement>
+
     <profiles>
         <profile>
             <id>it</id>
@@ -215,7 +235,7 @@
                             <dependency>
                                 <groupId>org.apache.groovy</groupId>
                                 <artifactId>groovy-all</artifactId>
-                                <version>4.0.16</version>
+                                <version>4.0.32</version>
                                 <type>pom</type>
                             </dependency>
                         </dependencies>


### PR DESCRIPTION
OSSRH is gone, and Sonatype CP is the new thing to publish. Use Njord and nothing changes in release process.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Maven project metadata and publishing configuration for Central Portal.
  * Replaced prior staging repository settings with Central-style distribution configuration.
  * Integrated Njord-based build/publishing properties and plugin integration into the build.

* **Dependencies**
  * Upgraded Groovy integration-test dependency to 4.0.32.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jbangdev/jbang-maven-plugin/pull/16?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->